### PR TITLE
Remove settors, optimize slider updating

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,25 +21,25 @@
           <div id="slider-container">
             <fieldset>
               <label for="x-divisions">x div:</label>
-              <output name="x-divisionsOutput" id="x-divisionsOutput" value="15" class="slider-output" ></output>
-              <input type="range" min="5" max="100" value="15" class="slider" id="x-divisions">
+              <output name="x-divisionsOutput" id="x-divisions-output" value="15" class="slider-output" ></output>
+              <input type="range" min="5" max="100" value="15" class="slider" id="x-divisions" data-key="xDivisions">
   
               <label for="y-divisions">y div:</label>
-              <output name="y-divisionsOutput" id="y-divisionsOutput" value="15" class="slider-output"></output>
-              <input type="range" min="5" max="80"  value="15" class="slider" id="y-divisions">
+              <output name="y-divisionsOutput" id="y-divisions-output" value="15" class="slider-output"></output>
+              <input type="range" min="5" max="80"  value="15" class="slider" id="y-divisions" data-key="yDivisions">
   
               <label for="ratio">ratio:</label>
-              <output name="ratio" id="ratio" value="50" class="slider-output"></output>
-              <input type="range" min="0" max="100"  value="50" class="slider" id="ratio">
+              <output name="ratio" id="ratio-output" value="50" class="slider-output"></output>
+              <input type="range" min="0" max="100"  value="50" class="slider" id="ratio" data-key="reductionRatio">
             </fieldset>
             <fieldset>
               <label for="x-offset">x offset:</label>
-              <output name="x-offset" id="x-offset" value="1" class="slider-output"></output>
-              <input type="range" min="0" max="100"  value="1" class="slider" id="x-offset">
+              <output name="x-offset" id="x-offset-output" value="1" class="slider-output"></output>
+              <input type="range" min="0" max="100"  value="1" class="slider" id="x-offset" data-key="xOffset">
   
               <label for="y-offset">y offset:</label>
-              <output name="y-offset" id="y-offset" value="1" class="slider-output"></output>
-              <input type="range" min="0" max="100"  value="1" class="slider" id="y-offset">
+              <output name="y-offset" id="y-offset-output" value="1" class="slider-output"></output>
+              <input type="range" min="0" max="100"  value="1" class="slider" id="y-offset" data-key="yOffset">
             </fieldset>
           </div>
         </form>          

--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,5 @@
 import loadImage from "blueimp-load-image";
 import todaysCuriosity from './todays-curiosity';
-//const todaysCuriosity = require('./todays-curiosity');
 
 // Check for the various File API support.
 if (window.File && window.FileReader && window.FileList && window.Blob) {
@@ -13,11 +12,7 @@ document.getElementById('file-input').onchange = function (e) {
   loadImage(
       e.target.files[0],
       function (img) {
-        // console.log(todaysCuriosity(img));
         const curiosity = new todaysCuriosity(img);
-        curiosity.setDivisions(10, 10);
-        curiosity.setReductionRatio(0.5)
-        curiosity.setOffset(0.2, 0.2);
         // const {inputCanvas, outputCanvas} = curiosity.getReducedPixelBlocks();
         const {inputCanvas, outputCanvas} = curiosity.getReversedPixelBlocks();
     
@@ -32,39 +27,28 @@ document.getElementById('file-input').onchange = function (e) {
   );
 };
 
-
-
-
-// mainScript();
-
 function listenerStuff(curiosity) {
   const update = (event) => {
-    curiosity.setDivisions(xDivisionsSlider.value, yDivisionsSlider.value)
-    curiosity.setReductionRatio(ratioSlider.value/100);
-    curiosity.setOffset(xOffsetSlider.value/100, yOffsetSlider.value/100);
+    const percentageKeys = ['reductionRatio', 'xOffset', 'yOffset'];
+    const targetKey = event.target.dataset.key;
+    const sliderOutput = document.getElementById(`${event.target.id}-output`);
+    sliderOutput.value = event.target.value;
 
-    sliders.forEach((slider, index) => {
-      sliderOutputs[index].value = slider.value;
-    });
-
+    if (percentageKeys.includes( targetKey ) ) {
+      curiosity[targetKey] = event.target.value / 100;  
+    } else {
+      curiosity[targetKey] = event.target.value;  
+    }
+  
     const {inputCanvas, outputCanvas} = curiosity.getReversedPixelBlocks();
-    
-    
-    const inputDiv = document.getElementById('input-display');
+
     inputDiv.appendChild(inputCanvas);
-    const outputDiv = document.getElementById('output-display');
     outputDiv.appendChild(outputCanvas);
   };
-  
-  const xDivisionsSlider = document.getElementById('x-divisions');
-  const yDivisionsSlider = document.getElementById('y-divisions');
-  const xOffsetSlider = document.getElementById('x-offset');
-  const yOffsetSlider = document.getElementById('y-offset');
-
-  const ratioSlider = document.getElementById('ratio');
+  const inputDiv = document.getElementById('input-display');
+  const outputDiv = document.getElementById('output-display');
   
   const sliders = document.querySelectorAll('.slider');
-  const sliderOutputs = document.querySelectorAll('.slider-output');
   sliders.forEach(input => input.addEventListener('change', update));
 }
 

--- a/todays-curiosity.js
+++ b/todays-curiosity.js
@@ -5,9 +5,7 @@ class todaysCuriosity {
     this.createCanvases();
     this.paintInputImage();
     this.createBrightpixels();
-    this.setDivisions();
-    this.setReductionRatio();
-    this.setOffset();
+    this.loadDefaultValues();
   }
   
   createCanvases() {
@@ -29,24 +27,21 @@ class todaysCuriosity {
     this.brightPixels = brightenPixels(pixels);
   }
   
-  setDivisions(xDivisions = 20, yDivisions = 20) {
-    this.xDivisions = xDivisions;
-    this.yDivisions = yDivisions;
+  loadDefaultValues() {
+    this.xDivisions = 20;
+    this.yDivisions = 20;
+    this.reductionRatio = 0.6;
+    this.xOffset = 0;
+    this.yOffset = 0;
   }
-  
-  setReductionRatio(reductionRatio = 1) {
-    this.reductionRatio = reductionRatio;
-  
-    this.outputCanvas.width = this.baseImage.width * reductionRatio;
-    this.outputCanvas.height = this.baseImage.height * reductionRatio;
-  }
-
-  setOffset(xOffset = 0, yOffset = 0) {
-    this.xOffset = xOffset;
-    this.yOffset = yOffset;
+    
+  _updateCanvasDimensions() {
+        this.outputCanvas.width = this.baseImage.width * this.reductionRatio;
+        this.outputCanvas.height = this.baseImage.height * this.reductionRatio;
   }
   
   getReducedPixelBlocks() {
+    this._updateCanvasDimensions();
     this.paintInputImage();
     this.loopThroughImageBlocks(this.paintReduceBlocks.bind(this));
 
@@ -66,6 +61,7 @@ class todaysCuriosity {
   }
 
   getReversedPixelBlocks(){
+    this._updateCanvasDimensions();
     this.paintInputImage();
     this.loopThroughImageBlocks(this.paintReverseBlocks.bind(this));
     this.outputCanvas.style.transform="scale(-1,-1)";


### PR DESCRIPTION
Hi bro,

So don't know if you noticed (maybe I should have created an issue) but the first time you moved a slider after loading an image noting would happen, but it would work after that. This first slider move also put an error in the console. I was able to figure out that the error was from the reductionRatio being 0, but did end up tracking down why it's wasn't being set correctly on init.

But then I started reading about gettors and settors in ES6 classes and came to the following opinionated conclusion, tell me what you think.

gettors and settors in JS are kinda usless since everything is public
and it's not worth the effort of using closures to make things public,
If you want to write an unbreakable library, don't use JS.
For now we'll instead concentrate on making the public interface clear
is '_' notation for private things, (TODO). This commits removes
settors.

Also on a separate note to settors, slider changes was updating every slider on the page instead of
using the event and focusing on the slider that changed, now fixed. though there are two distinct things happening in this PR, I probably should have made two. Sorry.