### PR TITLE
Load default image

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1,35 +1,45 @@
 import loadImage from "blueimp-load-image";
 import todaysCuriosity from './todays-curiosity';
-//const todaysCuriosity = require('./todays-curiosity');
+import george from './george.jpg';
 
 // Check for the various File API support.
 if (window.File && window.FileReader && window.FileList && window.Blob) {
   // alert('file api works')
 } else {
-  alert('Oh no, looks like your browser might be a bit old for this app to work. Maybe try the lates Chrome or Firefox. and call ghast busters');
+  alert('Oh no, looks like your browser might be a bit old for this app to work. Maybe try the latest Chrome or Firefox.');
 }
 
-const curiosity = new todaysCuriosity(new Image(20,20));
+let curiosity;
+
+const defaultImage = new Image();
+defaultImage.src = george;
+defaultImage.onload = function() {
+  console.log('onload', defaultImage);
+  curiosity = new todaysCuriosity(defaultImage);
+  imageSetup(defaultImage);
+};
 
 document.getElementById('file-input').onchange = function (e) {
   loadImage(
       e.target.files[0],
-      function (img) {
-        curiosity.baseImage = img;
-        curiosity.paintInputImage();
-        curiosity.createBrightpixels();
-        // const {inputCanvas, outputCanvas} = curiosity.getReducedPixelBlocks();
-        const {inputCanvas, outputCanvas} = curiosity.getReversedPixelBlocks();
-    
-        const inputDiv = document.getElementById('input-display');
-        inputDiv.appendChild(inputCanvas);
-        const outputDiv = document.getElementById('output-display');
-        outputDiv.appendChild(outputCanvas);
-        
-        listenerStuff(curiosity);
-      },
+      imageSetup,
       {maxWidth: 2000} // Options
   );
+};
+
+function imageSetup (img) {
+  curiosity.baseImage = img;
+  curiosity.paintInputImage();
+  curiosity.createBrightpixels();
+  // const {inputCanvas, outputCanvas} = curiosity.getReducedPixelBlocks();
+  const {inputCanvas, outputCanvas} = curiosity.getReversedPixelBlocks();
+
+  const inputDiv = document.getElementById('input-display');
+  inputDiv.appendChild(inputCanvas);
+  const outputDiv = document.getElementById('output-display');
+  outputDiv.appendChild(outputCanvas);
+  
+  listenerStuff(curiosity);
 };
 
 

--- a/scripts.js
+++ b/scripts.js
@@ -9,15 +9,15 @@ if (window.File && window.FileReader && window.FileList && window.Blob) {
   alert('Oh no, looks like your browser might be a bit old for this app to work. Maybe try the lates Chrome or Firefox. and call ghast busters');
 }
 
+const curiosity = new todaysCuriosity(new Image(20,20));
+
 document.getElementById('file-input').onchange = function (e) {
   loadImage(
       e.target.files[0],
       function (img) {
-        // console.log(todaysCuriosity(img));
-        const curiosity = new todaysCuriosity(img);
-        curiosity.setDivisions(10, 10);
-        curiosity.setReductionRatio(0.5)
-        curiosity.setOffset(0.2, 0.2);
+        curiosity.baseImage = img;
+        curiosity.paintInputImage();
+        curiosity.createBrightpixels();
         // const {inputCanvas, outputCanvas} = curiosity.getReducedPixelBlocks();
         const {inputCanvas, outputCanvas} = curiosity.getReversedPixelBlocks();
     
@@ -25,7 +25,7 @@ document.getElementById('file-input').onchange = function (e) {
         inputDiv.appendChild(inputCanvas);
         const outputDiv = document.getElementById('output-display');
         outputDiv.appendChild(outputCanvas);
-    
+        
         listenerStuff(curiosity);
       },
       {maxWidth: 2000} // Options


### PR DESCRIPTION
Issue with multiple images showing up when after second image load and not having default image solve together. Multiple images came from having multiple instances of todaysCuriosity class. A single instance is now made when the default image is loaded, all succeeding images use the original class.
