### PR TITLE
Replace image cropping with image scaling

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -24,7 +24,7 @@ document.getElementById('file-input').onchange = function (e) {
   loadImage(
     e.target.files[0],
     imageSetup
-  ).scale(2000);
+  ).scale({maxWidth: 2000});
 };
 
 document.getElementById('get-url').onclick = async function (e) {

--- a/scripts.js
+++ b/scripts.js
@@ -23,9 +23,8 @@ defaultImage.onload = () => {
 document.getElementById('file-input').onchange = function (e) {
   loadImage(
     e.target.files[0],
-    imageSetup,
-    {maxWidth: 2000} // Options
-  );
+    imageSetup
+  ).scale(2000);
 };
 
 document.getElementById('get-url').onclick = async function (e) {


### PR DESCRIPTION
Issue #33 requests images over a certain size be scaled down to a width of 2000 instead of being cropped down. This change addresses that issue.

I have confirmed the cropping issue with the current build and tested that it is no longer present with the changes.